### PR TITLE
Catch NoClassDefFoundError & bump version to 1.0.4 - fixes #13

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -7,15 +7,15 @@
   <parent>
     <groupId>org.openrefine.dependencies</groupId>
     <artifactId>butterfly-container</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
   </parent>
   
   <groupId>org.openrefine.dependencies</groupId>
   <artifactId>butterfly</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 
   <name>SIMILE Butterfly Engine</name>
-  <url>https://code.google.com/p/simile-butterfly/</url>
+  <url>https://github.com/OpenRefine/simile-butterfly/</url>
   <inceptionYear>2007</inceptionYear>
 
   <licenses>
@@ -105,7 +105,7 @@
           <groupId>com.sun.jmx</groupId>
           <artifactId>jmxtools</artifactId>
         </exclusion>
-      </exclusions>      
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/main/src/edu/mit/simile/butterfly/Butterfly.java
+++ b/main/src/edu/mit/simile/butterfly/Butterfly.java
@@ -475,7 +475,9 @@ public class Butterfly extends HttpServlet {
             try {
                 m.init(getServletConfig());
             } catch (Exception e) {
-                _configurationException = new Exception("Failed to initialize module " + m, e);
+                _configurationException = new Exception("Failed to initialize module: " + m, e);
+            } catch (NoClassDefFoundError e) {
+                _configurationException = new Exception("Failed to initialize module (missing Java class definition): " + m, e);
             }
             
             _logger.debug("< initialize " + m.getName());
@@ -888,7 +890,7 @@ public class Butterfly extends HttpServlet {
                             try {
                                 _logger.trace("> adding scriptable object: {}", scriptable);
                                 @SuppressWarnings("rawtypes")
-								Class c  = _classLoader.loadClass(scriptable);
+                                Class c  = _classLoader.loadClass(scriptable);
                                 ButterflyScriptableObject o = (ButterflyScriptableObject) c.newInstance();
                                 setScriptable(m, o);
                                 URL initializer = c.getResource("init.js");

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.openrefine.dependencies</groupId>
   <artifactId>butterfly-container</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <packaging>pom</packaging>
 
   <name>SIMILE Butterfly</name>
@@ -65,8 +65,8 @@
   </scm>
 
   <issueManagement>
-    <system>Google Code</system>
-    <url>https://code.google.com/p/simile-butterfly/issues/list</url>
+    <system>Github</system>
+    <url>https://github.com/OpenRefine/simile-butterfly/issues</url>
   </issueManagement>
 
   <build>


### PR DESCRIPTION
This will return the error and stack trace as an unstyled 500 page, but at least it:
- isn't hidden in the server log, and
- includes the name of the offending module and a more explicit error message