### PR TITLE
Update for Jetty 9. Set version to 1.1.0.

### DIFF
--- a/main/.classpath
+++ b/main/.classpath
@@ -18,6 +18,18 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="lib" path="/butterfly server/lib/servlet-api-2.5.jar"/>
+	<classpathentry kind="lib" path="webapp/WEB-INF/lib/slf4j-api-1.5.6.jar"/>
+	<classpathentry kind="lib" path="webapp/WEB-INF/lib/slf4j-log4j12-1.5.6.jar"/>
+	<classpathentry kind="lib" path="webapp/WEB-INF/lib/log4j-1.2.15.jar"/>
+	<classpathentry kind="lib" path="tests/lib/mockito-all-1.8.4.jar"/>
+	<classpathentry kind="lib" path="tests/lib/testng-5.12.1.jar"/>
+	<classpathentry kind="lib" path="webapp/WEB-INF/lib/rhino-1.7R2.jar" sourcepath="webapp/WEB-INF/lib-src/rhino-1.7R2-sources.jar"/>
+	<classpathentry kind="lib" path="webapp/WEB-INF/lib/tracer-1.0.jar"/>
+	<classpathentry kind="lib" path="webapp/WEB-INF/lib/commons-collections-3.2.1.jar"/>
+	<classpathentry kind="lib" path="webapp/WEB-INF/lib/commons-io-1.4.jar"/>
+	<classpathentry kind="lib" path="webapp/WEB-INF/lib/velocity-1.6.3.jar"/>
+	<classpathentry kind="lib" path="webapp/WEB-INF/lib/lessen-trunk-r8.jar"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -7,12 +7,12 @@
   <parent>
     <groupId>org.openrefine.dependencies</groupId>
     <artifactId>butterfly-container</artifactId>
-    <version>1.0.4</version>
+    <version>1.1.0</version>
   </parent>
   
   <groupId>org.openrefine.dependencies</groupId>
   <artifactId>butterfly</artifactId>
-  <version>1.0.4</version>
+  <version>1.1.0</version>
 
   <name>SIMILE Butterfly Engine</name>
   <url>https://github.com/OpenRefine/simile-butterfly/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.openrefine.dependencies</groupId>
   <artifactId>butterfly-container</artifactId>
-  <version>1.0.4</version>
+  <version>1.1.0</version>
   <packaging>pom</packaging>
 
   <name>SIMILE Butterfly</name>


### PR DESCRIPTION
I have tested this code in the new architecture, it seems to work well.
This upgrade is necessary for Debian packaging:
https://groups.google.com/g/openrefine-dev/c/hXwX_SqjXbg