### PR TITLE
Align Java versions in CI to OpenRefine's

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ 11, 16 ]
+        java: [ 11, 21 ]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Use both Java 11 and 21 which are LTS releases.