### PR TITLE
Bump commons-lang 2.6 to commons-lang3 3.20.0

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -91,9 +91,9 @@
       <version>2.18.0</version>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.20.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
Updates vulnerable commons-lang 2.6 to current Apache commons-lang3 3.20.0