### PR TITLE
DRAFT - Jakarta Servlet 5 update

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" 
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -9,10 +9,8 @@
     <artifactId>butterfly-container</artifactId>
     <version>1.2.7-SNAPSHOT</version>
   </parent>
-  
-  <groupId>org.openrefine.dependencies</groupId>
+
   <artifactId>butterfly</artifactId>
-  <version>1.2.7-SNAPSHOT</version>
 
   <name>SIMILE Butterfly Engine</name>
   <url>https://github.com/OpenRefine/simile-butterfly/</url>
@@ -111,9 +109,10 @@
       <version>1.9.1</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/main/src/edu/mit/simile/butterfly/Butterfly.java
+++ b/main/src/edu/mit/simile/butterfly/Butterfly.java
@@ -28,13 +28,13 @@ import java.util.TimeZone;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.collections.ExtendedProperties;
 import org.apache.velocity.app.VelocityEngine;

--- a/main/src/edu/mit/simile/butterfly/ButterflyModule.java
+++ b/main/src/edu/mit/simile/butterfly/ButterflyModule.java
@@ -9,10 +9,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.collections.ExtendedProperties;
 import org.apache.velocity.VelocityContext;

--- a/main/src/edu/mit/simile/butterfly/ButterflyModuleImpl.java
+++ b/main/src/edu/mit/simile/butterfly/ButterflyModuleImpl.java
@@ -27,10 +27,10 @@ import java.util.TimerTask;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.collections.ExtendedProperties;
 import org.apache.commons.collections.OrderedMap;

--- a/main/src/edu/mit/simile/butterfly/ButterflyMounter.java
+++ b/main/src/edu/mit/simile/butterfly/ButterflyMounter.java
@@ -6,7 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/main/src/edu/mit/simile/butterfly/ScriptableButterfly.java
+++ b/main/src/edu/mit/simile/butterfly/ScriptableButterfly.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;

--- a/main/tests/src/edu/mit/simile/butterfly/tests/ButterflyTest.java
+++ b/main/tests/src/edu/mit/simile/butterfly/tests/ButterflyTest.java
@@ -3,10 +3,9 @@ package edu.mit.simile.butterfly.tests;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
-import org.testng.annotations.BeforeSuite;
 
 import edu.mit.simile.butterfly.Butterfly;
 

--- a/main/tests/src/edu/mit/simile/butterfly/tests/ServletAPIExtensionTests.java
+++ b/main/tests/src/edu/mit/simile/butterfly/tests/ServletAPIExtensionTests.java
@@ -1,6 +1,6 @@
 package edu.mit.simile.butterfly.tests;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/main/tests/src/edu/mit/simile/butterfly/tests/ZoneTests.java
+++ b/main/tests/src/edu/mit/simile/butterfly/tests/ZoneTests.java
@@ -1,6 +1,6 @@
 package edu.mit.simile.butterfly.tests;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;


### PR DESCRIPTION
This needs testing, but is just a mechanical renaming of `javax.servlet.*` to `jakarta.servlet.*`. 

Because Jetty 12 reinstated Java Servlet 4 compatibility, we can actually use Jetty 12 without this, so I'm tempted to defer it.

Going to Servlet 6 just requires updating the POM. There are no required source code changes.